### PR TITLE
Tidy up for publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-# Sparse Set
+## 0.1.0.0
 
-Sparse Sets are useful when you have a lot of potential keys but only a small part of them is used. Sparse sets can deal with many keys while providing fast iteration over the values within the set.
-
-There are 4 variants:
-- Boxed: The standard version which can deal with arbitrary Haskell values
-- Storable: Can only deal with Storable values
-- Unboxed: Can only deal with Unbox(vector package) values
-- NoComponent: Contains no values, only the keys
+Initial release.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Sparse Set
+
+Sparse Sets are useful when you have a lot of potential keys but only a small part of them is used. Sparse sets can deal with many keys while providing fast iteration over the values within the set.
+
+There are 4 variants:
+- `Boxed`: The standard version which can deal with arbitrary Haskell values.
+- `Storable`: Can only deal with Storable values.
+- `Unboxed`: Can only deal with Unbox(vector package) values.
+- `NoComponent`: Contains no values, only the keys.

--- a/sparse-set.cabal
+++ b/sparse-set.cabal
@@ -5,7 +5,7 @@ synopsis:
 
 -- A longer description of the package.
 -- description:
-homepage:
+homepage: https://github.com/Simre1/sparse-set
 
 -- A URL where users can report bugs.
 -- bug-reports:
@@ -17,23 +17,61 @@ maintainer:         simre4775@gmail.com
 -- A copyright notice.
 -- copyright:
 category:           Data
-extra-source-files: CHANGELOG.md
+extra-source-files:
+  CHANGELOG.md,
+  README.md
 
 library
-    exposed-modules:  
-        SparseSet.Boxed
-        SparseSet.NoComponent
-        SparseSet.Storable
-        SparseSet.Unboxed
-    build-depends:    
-        base ^>=4.16.0.0,
+    exposed-modules:
+        Data.SparseSet.Boxed
+        Data.SparseSet.NoComponent
+        Data.SparseSet.Storable
+        Data.SparseSet.Unboxed
+    build-depends:
+        base >=4.14.0.0,
         vector
     hs-source-dirs:   src
-    default-language: GHC2021
+    default-extensions:
+      ApplicativeDo
+      BangPatterns
+      BlockArguments
+      ConstraintKinds
+      DeriveGeneric
+      DerivingStrategies
+      DuplicateRecordFields
+      FlexibleContexts
+      GeneralizedNewtypeDeriving
+      ImportQualifiedPost
+      KindSignatures
+      LambdaCase
+      OverloadedStrings
+      PatternSynonyms
+      RecordWildCards
+      StrictData
+      TypeApplications
 
 test-suite sparse-set-test
-    default-language: GHC2021
-    type:             exitcode-stdio-1.0
-    hs-source-dirs:   test
-    main-is:          MyLibTest.hs
-    build-depends:    base ^>=4.16.0.0
+    type: exitcode-stdio-1.0
+    hs-source-dirs: test
+    main-is: Main.hs
+    build-depends:
+      base >=4.14.0.0,
+      sparse-set
+    default-extensions:
+      ApplicativeDo
+      BangPatterns
+      BlockArguments
+      ConstraintKinds
+      DeriveGeneric
+      DerivingStrategies
+      DuplicateRecordFields
+      FlexibleContexts
+      GeneralizedNewtypeDeriving
+      ImportQualifiedPost
+      KindSignatures
+      LambdaCase
+      OverloadedStrings
+      PatternSynonyms
+      RecordWildCards
+      StrictData
+      TypeApplications

--- a/src/Data/SparseSet/Boxed.hs
+++ b/src/Data/SparseSet/Boxed.hs
@@ -1,8 +1,10 @@
-module SparseSet.NoComponent
-  ( SparseSetNoComponent,
+module Data.SparseSet.Boxed
+  ( SparseSetBoxed,
     create,
     insert,
     contains,
+    lookup,
+    unsafeLookup,
     size,
     remove,
     for,
@@ -21,6 +23,8 @@ import Data.IORef
     readIORef,
   )
 import Data.Kind (Constraint)
+import Data.Vector qualified as V
+import Data.Vector.Mutable qualified as VM
 import Data.Vector.Primitive qualified as VP
 import Data.Vector.Primitive.Mutable qualified as VPM
 import Data.Word (Word32)
@@ -31,60 +35,84 @@ import Prelude hiding (lookup)
 -- the index of an element to the dense array.
 -- The sparse set is useful when you have a lot of possible keys but not that many values
 -- to actually store. Iteration over the values is very quick.
-data SparseSetNoComponent = SparseSetNoComponent
-  { sparseSetSparse :: {-# UNPACK #-} !(VPM.IOVector Word32),
-    sparseSetEntities :: {-# UNPACK #-} !(VPM.IOVector Word32),
-    sparseSetSize :: {-# UNPACK #-} !(IORef Int)
+data SparseSetBoxed a = SparseSetBoxed
+  { sparseSetSparse :: {-# UNPACK #-} VPM.IOVector Word32,
+    sparseSetEntities :: {-# UNPACK #-} VPM.IOVector Word32,
+    sparseSetDense :: {-# UNPACK #-} VM.IOVector a,
+    sparseSetSize :: {-# UNPACK #-} IORef Int
   }
+
+type ElementConstraint a = () :: Constraint
 
 -- | Creates a sparse set with the first value as the sparse array size and the second as the dense array size.
 -- Given that the sparse array size is x, then keys from 0..x can be used. maxBound may never be used for x.
 -- Given that the dense array size is y, then y values can be stored. y should not be larger than x.
-create :: (MonadIO m) => Word32 -> Word32 -> m (SparseSetNoComponent)
+create :: (ElementConstraint a, MonadIO m) => Word32 -> Word32 -> m (SparseSetBoxed a)
 create sparseSize denseSize = liftIO $ do
   !sparse <- VPM.replicate (fromIntegral sparseSize) maxBound
+  !dense <- VM.new (fromIntegral denseSize)
   !entities <- VPM.new (fromIntegral denseSize)
   let !size = 0
-  SparseSetNoComponent sparse entities <$> newIORef size
+  SparseSetBoxed sparse entities dense <$> newIORef size
 {-# INLINE create #-}
 
 -- | Inserts a value into the sparse set at the given 'Word32' index.
 -- Overwrites the old value if there is one.
-insert :: (MonadIO m) => SparseSetNoComponent -> Word32 -> m ()
-insert (SparseSetNoComponent sparse entities sizeRef) i = liftIO $ do
+insert :: (ElementConstraint a, MonadIO m) => SparseSetBoxed a -> Word32 -> a -> m ()
+insert (SparseSetBoxed sparse entities dense sizeRef) i a = liftIO $ do
   index <- VPM.unsafeRead sparse (fromIntegral i)
   if index /= maxBound
-    then pure ()
+    then VM.unsafeWrite dense (fromIntegral index) a
     else do
       nextIndex <- atomicModifyIORef' sizeRef (\size -> (succ size, size))
-      let denseSize = VPM.length entities
+      let denseSize = VM.length dense
+      VM.unsafeWrite dense nextIndex a
       VPM.unsafeWrite entities nextIndex i
       VPM.unsafeWrite sparse (fromIntegral i) (fromIntegral nextIndex)
 {-# INLINE insert #-}
 
 -- | Returns true if the given key is in the set.
-contains :: MonadIO m => SparseSetNoComponent -> Word32 -> m Bool
-contains (SparseSetNoComponent sparse _ _) i = liftIO $ do
+contains :: MonadIO m => SparseSetBoxed a -> Word32 -> m Bool
+contains (SparseSetBoxed sparse _ _ _) i = liftIO $ do
   v <- VPM.unsafeRead sparse (fromIntegral i)
   pure $ v /= (maxBound :: Word32)
 {-# INLINE contains #-}
 
 -- | Returns the amount of values in the set
-size :: MonadIO m => SparseSetNoComponent -> m Int
-size (SparseSetNoComponent _ _ sizeRef) = liftIO $ readIORef sizeRef
+size :: MonadIO m => SparseSetBoxed a -> m Int
+size (SparseSetBoxed _ _ _ sizeRef) = liftIO $ readIORef sizeRef
 {-# INLINE size #-}
 
+-- | Returns the value at the given index or Nothing if the index is not within the set
+lookup :: (ElementConstraint a, MonadIO m) => SparseSetBoxed a -> Word32 -> m (Maybe a)
+lookup (SparseSetBoxed sparse _ dense _) i = liftIO $ do
+  index <- VPM.unsafeRead sparse (fromIntegral i)
+  if index /= maxBound
+    then Just <$> VM.unsafeRead dense (fromIntegral index)
+    else pure Nothing
+{-# INLINE lookup #-}
+
+-- | Returns the value at the given index. Only really safe directly after a 'contains' check
+--  and may segfault if the index does not exist.
+unsafeLookup :: (ElementConstraint a, MonadIO m) => SparseSetBoxed a -> Word32 -> m a
+unsafeLookup (SparseSetBoxed sparse _ dense _) i = liftIO $ do
+  index <- VPM.unsafeRead sparse (fromIntegral i)
+  VM.unsafeRead dense (fromIntegral index)
+{-# INLINE unsafeLookup #-}
+
 -- | Removes an index from the set. Does nothing if the index does not exist.
-remove :: (MonadIO m) => SparseSetNoComponent -> Word32 -> m ()
-remove (SparseSetNoComponent sparse entities sizeRef) i = liftIO $ do
+remove :: (ElementConstraint a, MonadIO m) => SparseSetBoxed a -> Word32 -> m ()
+remove (SparseSetBoxed sparse entities dense sizeRef) i = liftIO $ do
   index <- VPM.unsafeRead sparse (fromIntegral i)
   if index == maxBound
     then pure ()
     else do
       lastDenseIndex <- atomicModifyIORef sizeRef $ \size -> let s = max 0 (pred size) in (s, s)
 
+      lastElement <- VM.unsafeRead dense lastDenseIndex
       lastKey <- VPM.unsafeRead entities lastDenseIndex
 
+      VM.unsafeWrite dense (fromIntegral index) lastElement
       VPM.unsafeWrite entities (fromIntegral index) lastKey
 
       VPM.unsafeWrite sparse (fromIntegral lastKey) index
@@ -92,26 +120,28 @@ remove (SparseSetNoComponent sparse entities sizeRef) i = liftIO $ do
 {-# INLINE remove #-}
 
 -- | Iterate over all values with their corresponding key.
-for :: (MonadIO m) => SparseSetNoComponent -> (Word32 -> m ()) -> m ()
-for (SparseSetNoComponent _ entities sizeRef) f = do
+for :: (ElementConstraint a, MonadIO m) => SparseSetBoxed a -> (Word32 -> a -> m ()) -> m ()
+for (SparseSetBoxed _ entities dense sizeRef) f = do
   size <- liftIO $ readIORef sizeRef
 
   forM_ [0 .. pred size] $ \i -> do
     key <- liftIO $ VPM.unsafeRead entities i
+    val <- liftIO $ VM.unsafeRead dense i
 
-    f key
+    f key val
 {-# INLINE for #-}
 
 -- | Grows the dense array by 50 percent.
-growDense :: (MonadIO m) => SparseSetNoComponent -> m (SparseSetNoComponent)
-growDense (SparseSetNoComponent sparse entities sizeRef) = liftIO $ do
+growDense :: (ElementConstraint a, MonadIO m) => SparseSetBoxed a -> m (SparseSetBoxed a)
+growDense (SparseSetBoxed sparse entities dense sizeRef) = liftIO $ do
   let entitySize = VPM.length entities
+  newDense <- VM.unsafeGrow dense (entitySize `quot` 2)
   newEntities <- VPM.unsafeGrow entities (entitySize `quot` 2)
-  pure $ SparseSetNoComponent sparse newEntities sizeRef
+  pure $ SparseSetBoxed sparse newEntities newDense sizeRef
 
 -- | Visualizes the sparse set in the terminal. Mostly for debugging purposes.
-visualize :: MonadIO m => SparseSetNoComponent -> m ()
-visualize (SparseSetNoComponent sparse entities sizeRef) = liftIO $ do
+visualize :: MonadIO m => SparseSetBoxed a -> m ()
+visualize (SparseSetBoxed sparse entities sense sizeRef) = liftIO $ do
   size <- readIORef sizeRef
   putStrLn $ "SparseSet (" <> show size <> ")"
   putStr "Sparse: "

--- a/src/Data/SparseSet/NoComponent.hs
+++ b/src/Data/SparseSet/NoComponent.hs
@@ -1,10 +1,8 @@
-module SparseSet.Boxed
-  ( SparseSetBoxed,
+module Data.SparseSet.NoComponent
+  ( SparseSetNoComponent,
     create,
     insert,
     contains,
-    lookup,
-    unsafeLookup,
     size,
     remove,
     for,
@@ -23,8 +21,6 @@ import Data.IORef
     readIORef,
   )
 import Data.Kind (Constraint)
-import Data.Vector qualified as V
-import Data.Vector.Mutable qualified as VM
 import Data.Vector.Primitive qualified as VP
 import Data.Vector.Primitive.Mutable qualified as VPM
 import Data.Word (Word32)
@@ -35,84 +31,60 @@ import Prelude hiding (lookup)
 -- the index of an element to the dense array.
 -- The sparse set is useful when you have a lot of possible keys but not that many values
 -- to actually store. Iteration over the values is very quick.
-data SparseSetBoxed a = SparseSetBoxed
-  { sparseSetSparse :: {-# UNPACK #-} !(VPM.IOVector Word32),
-    sparseSetEntities :: {-# UNPACK #-} !(VPM.IOVector Word32),
-    sparseSetDense :: {-# UNPACK #-} !(VM.IOVector a),
-    sparseSetSize :: {-# UNPACK #-} !(IORef Int)
+data SparseSetNoComponent = SparseSetNoComponent
+  { sparseSetSparse :: {-# UNPACK #-} VPM.IOVector Word32,
+    sparseSetEntities :: {-# UNPACK #-} VPM.IOVector Word32,
+    sparseSetSize :: {-# UNPACK #-} IORef Int
   }
-
-type ElementConstraint a = () :: Constraint
 
 -- | Creates a sparse set with the first value as the sparse array size and the second as the dense array size.
 -- Given that the sparse array size is x, then keys from 0..x can be used. maxBound may never be used for x.
 -- Given that the dense array size is y, then y values can be stored. y should not be larger than x.
-create :: (ElementConstraint a, MonadIO m) => Word32 -> Word32 -> m (SparseSetBoxed a)
+create :: (MonadIO m) => Word32 -> Word32 -> m (SparseSetNoComponent)
 create sparseSize denseSize = liftIO $ do
   !sparse <- VPM.replicate (fromIntegral sparseSize) maxBound
-  !dense <- VM.new (fromIntegral denseSize)
   !entities <- VPM.new (fromIntegral denseSize)
   let !size = 0
-  SparseSetBoxed sparse entities dense <$> newIORef size
+  SparseSetNoComponent sparse entities <$> newIORef size
 {-# INLINE create #-}
 
 -- | Inserts a value into the sparse set at the given 'Word32' index.
 -- Overwrites the old value if there is one.
-insert :: (ElementConstraint a, MonadIO m) => SparseSetBoxed a -> Word32 -> a -> m ()
-insert (SparseSetBoxed sparse entities dense sizeRef) i a = liftIO $ do
+insert :: (MonadIO m) => SparseSetNoComponent -> Word32 -> m ()
+insert (SparseSetNoComponent sparse entities sizeRef) i = liftIO $ do
   index <- VPM.unsafeRead sparse (fromIntegral i)
   if index /= maxBound
-    then VM.unsafeWrite dense (fromIntegral index) a
+    then pure ()
     else do
       nextIndex <- atomicModifyIORef' sizeRef (\size -> (succ size, size))
-      let denseSize = VM.length dense
-      VM.unsafeWrite dense nextIndex a
+      let denseSize = VPM.length entities
       VPM.unsafeWrite entities nextIndex i
       VPM.unsafeWrite sparse (fromIntegral i) (fromIntegral nextIndex)
 {-# INLINE insert #-}
 
 -- | Returns true if the given key is in the set.
-contains :: MonadIO m => SparseSetBoxed a -> Word32 -> m Bool
-contains (SparseSetBoxed sparse _ _ _) i = liftIO $ do
+contains :: MonadIO m => SparseSetNoComponent -> Word32 -> m Bool
+contains (SparseSetNoComponent sparse _ _) i = liftIO $ do
   v <- VPM.unsafeRead sparse (fromIntegral i)
   pure $ v /= (maxBound :: Word32)
 {-# INLINE contains #-}
 
 -- | Returns the amount of values in the set
-size :: MonadIO m => SparseSetBoxed a -> m Int
-size (SparseSetBoxed _ _ _ sizeRef) = liftIO $ readIORef sizeRef
+size :: MonadIO m => SparseSetNoComponent -> m Int
+size (SparseSetNoComponent _ _ sizeRef) = liftIO $ readIORef sizeRef
 {-# INLINE size #-}
 
--- | Returns the value at the given index or Nothing if the index is not within the set
-lookup :: (ElementConstraint a, MonadIO m) => SparseSetBoxed a -> Word32 -> m (Maybe a)
-lookup (SparseSetBoxed sparse _ dense _) i = liftIO $ do
-  index <- VPM.unsafeRead sparse (fromIntegral i)
-  if index /= maxBound
-    then Just <$> VM.unsafeRead dense (fromIntegral index)
-    else pure Nothing
-{-# INLINE lookup #-}
-
--- | Returns the value at the given index. Only really safe directly after a 'contains' check
---  and may segfault if the index does not exist.
-unsafeLookup :: (ElementConstraint a, MonadIO m) => SparseSetBoxed a -> Word32 -> m a
-unsafeLookup (SparseSetBoxed sparse _ dense _) i = liftIO $ do
-  index <- VPM.unsafeRead sparse (fromIntegral i)
-  VM.unsafeRead dense (fromIntegral index)
-{-# INLINE unsafeLookup #-}
-
 -- | Removes an index from the set. Does nothing if the index does not exist.
-remove :: (ElementConstraint a, MonadIO m) => SparseSetBoxed a -> Word32 -> m ()
-remove (SparseSetBoxed sparse entities dense sizeRef) i = liftIO $ do
+remove :: (MonadIO m) => SparseSetNoComponent -> Word32 -> m ()
+remove (SparseSetNoComponent sparse entities sizeRef) i = liftIO $ do
   index <- VPM.unsafeRead sparse (fromIntegral i)
   if index == maxBound
     then pure ()
     else do
       lastDenseIndex <- atomicModifyIORef sizeRef $ \size -> let s = max 0 (pred size) in (s, s)
 
-      lastElement <- VM.unsafeRead dense lastDenseIndex
       lastKey <- VPM.unsafeRead entities lastDenseIndex
 
-      VM.unsafeWrite dense (fromIntegral index) lastElement
       VPM.unsafeWrite entities (fromIntegral index) lastKey
 
       VPM.unsafeWrite sparse (fromIntegral lastKey) index
@@ -120,28 +92,26 @@ remove (SparseSetBoxed sparse entities dense sizeRef) i = liftIO $ do
 {-# INLINE remove #-}
 
 -- | Iterate over all values with their corresponding key.
-for :: (ElementConstraint a, MonadIO m) => SparseSetBoxed a -> (Word32 -> a -> m ()) -> m ()
-for (SparseSetBoxed _ entities dense sizeRef) f = do
+for :: (MonadIO m) => SparseSetNoComponent -> (Word32 -> m ()) -> m ()
+for (SparseSetNoComponent _ entities sizeRef) f = do
   size <- liftIO $ readIORef sizeRef
 
   forM_ [0 .. pred size] $ \i -> do
     key <- liftIO $ VPM.unsafeRead entities i
-    val <- liftIO $ VM.unsafeRead dense i
 
-    f key val
+    f key
 {-# INLINE for #-}
 
 -- | Grows the dense array by 50 percent.
-growDense :: (ElementConstraint a, MonadIO m) => SparseSetBoxed a -> m (SparseSetBoxed a)
-growDense (SparseSetBoxed sparse entities dense sizeRef) = liftIO $ do
+growDense :: (MonadIO m) => SparseSetNoComponent -> m (SparseSetNoComponent)
+growDense (SparseSetNoComponent sparse entities sizeRef) = liftIO $ do
   let entitySize = VPM.length entities
-  newDense <- VM.unsafeGrow dense (entitySize `quot` 2)
   newEntities <- VPM.unsafeGrow entities (entitySize `quot` 2)
-  pure $ SparseSetBoxed sparse newEntities newDense sizeRef
+  pure $ SparseSetNoComponent sparse newEntities sizeRef
 
 -- | Visualizes the sparse set in the terminal. Mostly for debugging purposes.
-visualize :: MonadIO m => SparseSetBoxed a -> m ()
-visualize (SparseSetBoxed sparse entities sense sizeRef) = liftIO $ do
+visualize :: MonadIO m => SparseSetNoComponent -> m ()
+visualize (SparseSetNoComponent sparse entities sizeRef) = liftIO $ do
   size <- readIORef sizeRef
   putStrLn $ "SparseSet (" <> show size <> ")"
   putStr "Sparse: "

--- a/src/Data/SparseSet/Storable.hs
+++ b/src/Data/SparseSet/Storable.hs
@@ -1,4 +1,4 @@
-module SparseSet.Storable
+module Data.SparseSet.Storable
   ( SparseSetStorable,
     create,
     insert,
@@ -36,10 +36,10 @@ import Prelude hiding (lookup)
 -- The sparse set is useful when you have a lot of possible keys but not that many values
 -- to actually store. Iteration over the values is very quick.
 data SparseSetStorable a = SparseSetStorable
-  { sparseSetSparse :: {-# UNPACK #-} !(VPM.IOVector Word32),
-    sparseSetEntities :: {-# UNPACK #-} !(VPM.IOVector Word32),
-    sparseSetDense :: {-# UNPACK #-} !(VM.IOVector a),
-    sparseSetSize :: {-# UNPACK #-} !(IORef Int)
+  { sparseSetSparse :: {-# UNPACK #-} VPM.IOVector Word32,
+    sparseSetEntities :: {-# UNPACK #-} VPM.IOVector Word32,
+    sparseSetDense :: {-# UNPACK #-} VM.IOVector a,
+    sparseSetSize :: {-# UNPACK #-} IORef Int
   }
 
 type ElementConstraint a = V.Storable a :: Constraint

--- a/src/Data/SparseSet/Unboxed.hs
+++ b/src/Data/SparseSet/Unboxed.hs
@@ -1,4 +1,4 @@
-module SparseSet.Unboxed
+module Data.SparseSet.Unboxed
   ( SparseSetUnboxed,
     create,
     insert,
@@ -36,10 +36,10 @@ import Prelude hiding (lookup)
 -- The sparse set is useful when you have a lot of possible keys but not that many values
 -- to actually store. Iteration over the values is very quick.
 data SparseSetUnboxed a = SparseSetUnboxed
-  { sparseSetSparse :: {-# UNPACK #-} !(VPM.IOVector Word32),
-    sparseSetEntities :: {-# UNPACK #-} !(VPM.IOVector Word32),
-    sparseSetDense :: {-# UNPACK #-} !(VM.IOVector a),
-    sparseSetSize :: {-# UNPACK #-} !(IORef Int)
+  { sparseSetSparse :: {-# UNPACK #-} VPM.IOVector Word32,
+    sparseSetEntities :: {-# UNPACK #-} VPM.IOVector Word32,
+    sparseSetDense :: VM.IOVector a,
+    sparseSetSize :: {-# UNPACK #-} IORef Int
   }
 
 type ElementConstraint a = V.Unbox a :: Constraint

--- a/src/MyLib.hs
+++ b/src/MyLib.hs
@@ -1,4 +1,0 @@
-module MyLib (someFunc) where
-
-someFunc :: IO ()
-someFunc = putStrLn "someFunc"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,6 @@
 module Main (main) where
 
+import Data.SparseSet.Boxed qualified as Boxed
+
 main :: IO ()
 main = putStrLn "Test suite not yet implemented."


### PR DESCRIPTION
- GHC version lowered to 8.10 (base version, default-language)
- Modules moved into Data.* namespace
- Use StrictData and clean up record fields
- Cabal cleanup
- Readme/changelog swapped